### PR TITLE
Fix: Product Fetch Issues (CORS and 403 Forbidden)

### DIFF
--- a/backend/src/main/java/com/ecommerce/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/ecommerce/backend/config/WebConfig.java
@@ -15,7 +15,7 @@ public class WebConfig {
       public void addCorsMappings(CorsRegistry registry) {
         registry
             .addMapping("/api/**")
-            .allowedOrigins("http://localhost:3000") // Allow Frontend
+            .allowedOrigins("http://localhost:3000", "http://localhost:5173") // Allow Frontend
             .allowedMethods("GET", "POST", "PUT", "DELETE")
             .allowedHeaders("*");
       }

--- a/backend/src/main/java/com/ecommerce/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/ecommerce/backend/config/security/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
     http.csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers("/api/auth/**", "/h2-console/**")
+                auth.requestMatchers("/api/auth/**", "/h2-console/**", "/api/products/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())


### PR DESCRIPTION
Fixes #10.
- Allowed CORS origin http://localhost:5173 for Vite.
- Permitted public access to /api/products/**.